### PR TITLE
Install python as a mesos dependency

### DIFF
--- a/provision-mesos-master.sh
+++ b/provision-mesos-master.sh
@@ -7,3 +7,4 @@ sudo sh -c "echo manual > /etc/init/mesos-slave.override"
 sudo service zookeeper restart
 sudo service mesos-master restart
 sudo service marathon restart
+pip install mesos.cli

--- a/provision.sh
+++ b/provision.sh
@@ -15,7 +15,7 @@ echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME}-testing main" | sudo 
 sudo add-apt-repository -y ppa:openjdk-r/ppa
 sudo apt-get -y update
 # Install
-sudo apt-get -y install openjdk-8-jre
+sudo apt-get -y install openjdk-8-jre python-minimal python-pip
 sudo update-alternatives --config java
 # Install mesos and marathon
 sudo apt-get -y install mesos=1.1.0-2.0.107.ubuntu1604 marathon=1.3.0-1.0.506.ubuntu1604


### PR DESCRIPTION
* Install python/python-pip and mesos.cli

Apparently the AWS ubuntu instance doesn't have python installed and installing it after mesos causes weird issues, so installing it before with pip and then installing mesos.cli only on master
